### PR TITLE
Fix overlapping sources in test target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             name: "MinIOPhotoSync",
             dependencies: [],
             path: ".",
-            exclude: ["README.md"],
+            exclude: ["README.md", "Tests"],
             resources: [
                 .process("Resources")
             ]


### PR DESCRIPTION
This PR fixes the Xcode error: "target MinIOPhotoSyncTests has overlapping sources".

The issue was caused by the main target including all files in the root directory, including the Tests directory, while the test target was also including the Tests directory. This caused the test files to be included in both targets.

The fix excludes the Tests directory from the main target, ensuring that test files are only included in the test target.