### PR TITLE
XCodeビルドエラーの修正

### DIFF
--- a/MinIOPhotoSync-Bridging-Header.h
+++ b/MinIOPhotoSync-Bridging-Header.h
@@ -1,0 +1,6 @@
+#ifndef MinIOPhotoSync_Bridging_Header_h
+#define MinIOPhotoSync_Bridging_Header_h
+
+#import <CommonCrypto/CommonCrypto.h>
+
+#endif /* MinIOPhotoSync_Bridging_Header_h */

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,9 @@ let package = Package(
             exclude: ["README.md", "Tests"],
             resources: [
                 .process("Resources")
+            ],
+            swiftSettings: [
+                .unsafeFlags(["-import-objc-header", "MinIOPhotoSync-Bridging-Header.h"])
             ]
         ),
         .testTarget(

--- a/Resources/LaunchScreen.storyboard
+++ b/Resources/LaunchScreen.storyboard
@@ -16,29 +16,29 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MinIO Photo Sync" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Oa-Gg-7Jb">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MinIO Photo Sync" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="label1">
                                 <rect key="frame" x="20" y="432.5" width="374" height="31.5"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="photo.on.rectangle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Ygc-Yd-Ixf">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="photo.on.rectangle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="imageView1">
                                 <rect key="frame" x="157" y="324" width="100" height="98.5"/>
                                 <color key="tintColor" systemColor="systemBlueColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="100" id="Aqf-Yd-Ixf"/>
-                                    <constraint firstAttribute="height" constant="100" id="Ygc-Yd-Ixf"/>
+                                    <constraint firstAttribute="width" constant="100" id="width1"/>
+                                    <constraint firstAttribute="height" constant="100" id="height1"/>
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <viewLayoutGuide key="safeArea" id="safeArea"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="5Oa-Gg-7Jb" firstAttribute="top" secondItem="Ygc-Yd-Ixf" secondAttribute="bottom" constant="10" id="5Oa-Gg-7Jb"/>
-                            <constraint firstItem="5Oa-Gg-7Jb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="6Tk-OE-BBY"/>
-                            <constraint firstItem="5Oa-Gg-7Jb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="Aqf-Yd-Ixf"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="5Oa-Gg-7Jb" secondAttribute="trailing" constant="20" id="Ygc-Yd-Ixf"/>
-                            <constraint firstItem="Ygc-Yd-Ixf" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="Ze5-6b-2t3"/>
+                            <constraint firstItem="label1" firstAttribute="top" secondItem="imageView1" secondAttribute="bottom" constant="10" id="constraint1"/>
+                            <constraint firstItem="label1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="constraint2"/>
+                            <constraint firstItem="label1" firstAttribute="leading" secondItem="safeArea" secondAttribute="leading" constant="20" id="constraint3"/>
+                            <constraint firstItem="safeArea" firstAttribute="trailing" secondItem="label1" secondAttribute="trailing" constant="20" id="constraint4"/>
+                            <constraint firstItem="imageView1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="constraint5"/>
                         </constraints>
                     </view>
                 </viewController>


### PR DESCRIPTION
このPRでは、XCodeでのビルドエラーを修正しています。

## 修正内容

1. **CommonCryptoの追加**: 
   - PhotoSyncViewModel.swiftにCommonCryptoをインポートしました
   - SHA256ハッシュの計算部分をCryptoKitからCommonCryptoを使用する方法に変更しました
   - Bridging Headerファイルを作成してCommonCryptoをインポートできるようにしました
   - Package.swiftファイルを更新してBridging Headerを含めるようにしました

2. **非推奨関数の置き換え**:
   - `arc4random_uniform`関数を`Int.random(in:)`に置き換えました

3. **LaunchScreen.storyboardの修正**:
   - 重複したIDを持つ要素を修正しました
   - すべての要素に一意のIDを割り当てました