### PR TITLE
MinIOXMLParserのエラーを修正しモデル定義をリファクタリング

### DIFF
--- a/MinIOXMLParser.swift
+++ b/MinIOXMLParser.swift
@@ -1,4 +1,5 @@
 import Foundation
+// 共通のモデル定義をインポート
 
 class MinIOXMLParser: NSObject, XMLParserDelegate {
     private var currentElement = ""
@@ -88,7 +89,23 @@ class MinIOXMLParser: NSObject, XMLParserDelegate {
     
     func parser(_ parser: XMLParser, foundCDATA CDATABlock: Data) {
         if let string = String(data: CDATABlock, encoding: .utf8) {
-            parser(parser, foundCharacters: string)
+            // CDATAブロックの内容を文字列として処理
+            let data = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            
+            if isInContents && !data.isEmpty {
+                switch currentElement {
+                case "Key":
+                    currentKey += data
+                case "LastModified":
+                    currentLastModified += data
+                case "ETag":
+                    currentETag += data
+                case "Size":
+                    currentSize += data
+                default:
+                    break
+                }
+            }
         }
     }
 }

--- a/Models.swift
+++ b/Models.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Photos
+import UIKit
+
+// 共通のモデル定義
+enum SyncStatus {
+    case notSynced
+    case syncing
+    case synced
+    case failed
+}
+
+struct LocalPhoto: Identifiable {
+    let id: String
+    let asset: PHAsset
+    let thumbnail: UIImage
+    var syncStatus: SyncStatus = .notSynced
+    var lastModifiedDate: Date
+    var checksum: String?
+}
+
+struct MinIOPhoto: Identifiable {
+    let id: String
+    let url: URL
+    let lastModifiedDate: Date
+    let checksum: String?
+}

--- a/PhotoSyncViewModel.swift
+++ b/PhotoSyncViewModel.swift
@@ -1,29 +1,7 @@
 import Foundation
 import Photos
 import UIKit
-
-enum SyncStatus {
-    case notSynced
-    case syncing
-    case synced
-    case failed
-}
-
-struct LocalPhoto: Identifiable {
-    let id: String
-    let asset: PHAsset
-    let thumbnail: UIImage
-    var syncStatus: SyncStatus = .notSynced
-    var lastModifiedDate: Date
-    var checksum: String?
-}
-
-struct MinIOPhoto: Identifiable {
-    let id: String
-    let url: URL
-    let lastModifiedDate: Date
-    let checksum: String?
-}
+// 共通のモデル定義をインポート
 
 class PhotoSyncViewModel: ObservableObject {
     @Published var localPhotos: [LocalPhoto] = []


### PR DESCRIPTION
このPRでは、MinIOXMLParserのエラーを修正し、モデル定義をリファクタリングしています。

## 修正内容

1. **MinIOXMLParserのエラー修正**: 
   - `parser(parser, foundCharacters: string)`の呼び出しを修正し、CDATAブロックを正しく処理するようにしました

2. **モデル定義のリファクタリング**:
   - 共通のモデル定義（SyncStatus、LocalPhoto、MinIOPhoto）を新しいModels.swiftファイルに移動しました
   - これにより、複数のファイル間でモデルを共有しやすくなりました